### PR TITLE
logging.warn => logging.warning

### DIFF
--- a/bet/postProcess/compareP.py
+++ b/bet/postProcess/compareP.py
@@ -407,7 +407,8 @@ class comparison(object):
             self._ptr_left_local = None
             self._den_left = None
         elif isinstance(sample_set, samp.discretization):
-            logging.warn("Discretization passed. Assuming input set.")
+            msg = "Discretization passed. Assuming input set."
+            logging.warning(msg)
             sample_set = sample_set.get_input_sample_set()
             self._left_sample_set = sample_set
             self._ptr_left = None
@@ -478,7 +479,8 @@ class comparison(object):
             self._ptr_right_local = None
             self._den_right = None
         elif isinstance(sample_set, samp.discretization):
-            logging.warn("Discretization passed. Assuming input set.")
+            msg = "Discretization passed. Assuming input set."
+            logging.warning(msg)
             sample_set = sample_set.get_input_sample_set()
             self._right_sample_set = sample_set
             self._ptr_right = None
@@ -897,24 +899,24 @@ class comparison(object):
         if left_set._volumes is None:
             if comparison_sample_set is None:
                 msg = " Volumes missing from left. Using MC assumption."
-                logging.warn(msg)
+                logging.warning(msg)
                 left_set.estimate_volume_mc()
             else:
                 self.set_left_volume_comparison(comparison_sample_set)
         else:  # volumes present and comparison passed
             if comparison_sample_set is not None:
                 msg = " Overwriting left volumes with comparison ones."
-                logging.warn(msg)
+                logging.warning(msg)
                 self.set_left_volume_comparison(comparison_sample_set)
 
         if right_set._volumes is None:
             if comparison_sample_set is None:
                 msg = " Volumes missing from right. Using MC assumption."
-                logging.warn(msg)
+                logging.warning(msg)
                 right_set.estimate_volume_mc()
             else:
                 msg = " Overwriting right volumes with comparison ones."
-                logging.warn(msg)
+                logging.warning(msg)
                 self.set_right_volume_comparison(comparison_sample_set)
         else:  # volumes present and comparison passed
             if comparison_sample_set is not None:

--- a/bet/sample.py
+++ b/bet/sample.py
@@ -820,7 +820,7 @@ class sample_set_base(object):
         if densities is not None:
             self._densities = densities
         else:
-            logging.warn("Setting densities with probability/volume.")
+            logging.warning("Setting densities with probability/volume.")
             probs = self._probabilities
             vols = self._volumes
             self._densities = probs / vols
@@ -1000,7 +1000,8 @@ class sample_set_base(object):
         if densities_local is not None:
             self._densities_local = densities_local
         else:
-            logging.warn("Setting densities with probability/volume.")
+            msg = "Setting densities with probability/volume."
+            logging.warning(msg)
             probs = self._probabilities_local
             vols = self._volumes_local
             self._densities_local = probs / vols


### PR DESCRIPTION
a couple of these slipped past me. the following is thrown but doesn't cause errors in tests:
```DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead```
With `logging.warning`, this is suppressed entirely 